### PR TITLE
Ignore objects with no properties in Swagger parser

### DIFF
--- a/src/parsers/swagger/index.ts
+++ b/src/parsers/swagger/index.ts
@@ -33,7 +33,7 @@ function parseDefinitions(definitions: any[], ast: AST = {} as AST): AST {
 function parseDefinition(d: any, ast: AST): void {
     // no duplicate types
     if (!ast[d.name]) {
-        if (d.internalType === 'object' || !d.internalType) {
+        if ((d.internalType === 'object' && d.hasOwnProperty('properties')) || !d.internalType) {
 
             const astType = {} as GraphQLType
 


### PR DESCRIPTION
# Ignore objects with no properties in Swagger parser

### Purpose

The current version graphql-liftoff's swagger parser will fail to continue if it encounters an object without properties.  Occasionally swagger may have objects that do not have any properties. While these may be ignored for schema generation purposes, they currently cause liftoff to throw. The error is:

```
TypeError: Cannot read property 'map' of undefined
    at parseDefinition (/Users/jcummins/projects/graphql-liftoff/build/parsers/swagger/index.js:51:42)
    at definitions.map (/Users/jcummins/projects/graphql-liftoff/build/parsers/swagger/index.js:42:28)
    at Array.map (<anonymous>)
    at parseDefinitions (/Users/jcummins/projects/graphql-liftoff/build/parsers/swagger/index.js:42:17)
    at transformer.getModelFromData.then (/Users/jcummins/projects/graphql-liftoff/build/parsers/swagger/index.js:25:20)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

This PR is fixes this by checking to make sure there are properties on the object before mapping over them. 

Note: no tests are provided since all tests are currently stubbed out.
  
### Checklist
 - [ ] Maintainer Code Review
 