### PR TITLE
Fix Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     },
     "scripts": {
         "clean": "rimraf coverage build tmp",
-        "install": "tsc",
-        "build": "tsc",
-        "watch": "tsc -w",
+        "install": "node_modules/typescript/bin/tsc",
+        "build": "node_modules/typescript/bin/tsc",
+        "watch": "node_modules/typescript/bin/tsc -w",
         "lint": "tslint -t stylish --type-check --project \"tsconfig.json\"",
         "pretest": "tslint -t stylish --type-check --project \"tsconfig.json\"",
         "test": "jest --no-cache --coverage",

--- a/test/unit/utils/index.spec.js
+++ b/test/unit/utils/index.spec.js
@@ -42,7 +42,7 @@ describe('getContent', () => {
         // when
         return getContent(file).catch(err => {
             // then
-            expect(err.code).toEqual('ENOTSUP')
+            expect(err.code).toMatch(/E(NOTSUP|ISDIR)/)
         })
     })
 


### PR DESCRIPTION
# graphql-liftoff Fix travis

### Purpose

Travis is failing presumably because the vm/container it's running in has a preinstalled older version of tsc, which is being called instead of the new npm version. Switching all scripts to explicitly use those instead.
  
### Checklist
 - [ ] Maintainer Code Review
