### PR TITLE
add snake->camel case + type prefixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "Copyright (c) 2017 Target Brands, Inc."
     ],
     "name": "graphql-liftoff",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "description": "generates GraphQL schema language from API specifications and more",
     "engineStrict": true,
     "engines": {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -86,7 +86,7 @@ async function exec(parser: string, mArgs: string[], stdin: boolean): Promise<an
 }
 
 function usage(): void {
-    console.log(`usage: ${(pkg as any).name} [--help|-h] <parser> [--key=value|--key|-k] <filename|url|none-for-stdin>
+    console.log(`usage: ${(pkg as any).name} [--help|-h] <parser> [--key=value|-k=value|--key|-k] <filename|url|none-for-stdin>
 
 description:
 \t${(pkg as any).name} ${(pkg as any).description}

--- a/src/parsers/swagger/index.ts
+++ b/src/parsers/swagger/index.ts
@@ -10,7 +10,7 @@ let prefix: string = ''
 export async function parse(content: string, options: any): Promise<AST> {
     if (isOptionSet(options, 'c', 'camel-case')) { isCamelCase = true }
     if (isOptionSet(options, 'p', 'prefix-type-name')) {
-        prefix = String(getOptionValue(options, 'p', 'prefix-type-name'))
+        prefix = getOptionValue(options, 'p', 'prefix-type-name')
         isPrefix = true
     }
     if (isOptionSet(options, 'y', 'yaml')) { isYAML = true }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,25 +52,32 @@ function convertSnakeToCamel(s: string): string {
 }
 
 export function toCamel(ast: AST): AST {
-    Object
+    return Object
         .keys(ast)
-        .map((n: string, i: number) => {
-            ast[n].name = convertSnakeToCamel(ast[n].name)
-            ast[n].fields
-                .map((f: GraphQLField, fi: number) => {
-                    ast[n].fields[fi].name = convertSnakeToCamel(ast[n].fields[fi].name)
+        .reduce((acc: AST, cur: string, idx: number) => {
+            acc[cur] = {
+                name: convertSnakeToCamel(ast[cur].name),
+                description: ast[cur].description,
+                fields: ast[cur].fields.map(f => {
+                    f.name = convertSnakeToCamel(f.name)
+                    return f
                 })
-        })
-    return ast
+            } as GraphQLType
+            return acc
+        }, {} as AST)
 }
 
 export function addPrefix(ast: AST, prefix: String): AST {
-    Object
+    return Object
         .keys(ast)
-        .map((n: string, i: number) => {
-            ast[n].name = prefix + ast[n].name
-        })
-    return ast
+        .reduce((acc: AST, cur: string) => {
+            acc[cur] = {
+                name: prefix + ast[cur].name,
+                description: ast[cur].description,
+                fields: ast[cur].fields
+            } as GraphQLType
+            return acc
+        }, {} as AST)
 }
 
 export function isOptionSet(options: any, short: string, long: string): boolean {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,7 +41,7 @@ export function parserUsage(parser: string, args: Arg[]) {
         description: 'Show this help documentation'
     } as Arg)
     const sorted = args.sort((a: Arg, b: Arg) => a.long.localeCompare(b.long))
-    console.log(`usage: ${(pkg as any).name} ${parser} [--key=value|--key|-k] <filename|url|none-for-stdin>\n\noptions:`)
+    console.log(`usage: ${(pkg as any).name} ${parser} [--key=value|-k=value|--key|-k] <filename|url|none-for-stdin>\n\noptions:`)
     sorted.map(a => {
         console.log(`\t--${a.long},-${a.short}\t${a.description}`)
     })
@@ -74,10 +74,7 @@ export function addPrefix(ast: AST, prefix: String): AST {
 }
 
 export function isOptionSet(options: any, short: string, long: string): boolean {
-    if (options.hasOwnProperty(short) || options.hasOwnProperty(long)) {
-        return true
-    }
-    return false
+    return options.hasOwnProperty(short) || options.hasOwnProperty(long)
 }
 
 export function getOptionValue(options: any, short: string, long: string): any {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -46,3 +46,7 @@ export function parserUsage(parser: string, args: Arg[]) {
         console.log(`\t--${a.long},-${a.short}\t${a.description}`)
     })
 }
+
+export function convertSnakeToCamel(s: string) {
+    return s.replace(/(\_\w)/g, m => m[1].toUpperCase())
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -47,6 +47,43 @@ export function parserUsage(parser: string, args: Arg[]) {
     })
 }
 
-export function convertSnakeToCamel(s: string) {
+function convertSnakeToCamel(s: string): string {
     return s.replace(/(\_\w)/g, m => m[1].toUpperCase())
+}
+
+export function toCamel(ast: AST): AST {
+    Object
+        .keys(ast)
+        .map((n: string, i: number) => {
+            ast[n].name = convertSnakeToCamel(ast[n].name)
+            ast[n].fields
+                .map((f: GraphQLField, fi: number) => {
+                    ast[n].fields[fi].name = convertSnakeToCamel(ast[n].fields[fi].name)
+                })
+        })
+    return ast
+}
+
+export function addPrefix(ast: AST, prefix: String): AST {
+    Object
+        .keys(ast)
+        .map((n: string, i: number) => {
+            ast[n].name = prefix + ast[n].name
+        })
+    return ast
+}
+
+export function isOptionSet(options: any, short: string, long: string): boolean {
+    if (options.hasOwnProperty(short) || options.hasOwnProperty(long)) {
+        return true
+    }
+    return false
+}
+
+export function getOptionValue(options: any, short: string, long: string): any {
+    if (options.hasOwnProperty(short)) {
+        return options[short]
+    } else if (options.hasOwnProperty(long)) {
+        return options[long]
+    }
 }

--- a/test/unit/utils/index.spec.js
+++ b/test/unit/utils/index.spec.js
@@ -71,7 +71,7 @@ describe('parser usage', () => {
         // given
         const parser = 'example'
         const args = []
-        const expected = `usage: graphql-liftoff example [--key=value|--key|-k] <filename|url|none-for-stdin>
+        const expected = `usage: graphql-liftoff example [--key=value|-k=value|--key|-k] <filename|url|none-for-stdin>
 
 options:
 \t--help,-h	Show this help documentation
@@ -93,7 +93,7 @@ options:
                 description: 'test description'
             }
         ]
-        const expected = `usage: graphql-liftoff example [--key=value|--key|-k] <filename|url|none-for-stdin>
+        const expected = `usage: graphql-liftoff example [--key=value|-k=value|--key|-k] <filename|url|none-for-stdin>
 
 options:
 \t--help,-h	Show this help documentation

--- a/test/unit/utils/index.spec.js
+++ b/test/unit/utils/index.spec.js
@@ -1,4 +1,4 @@
-import { getContent, parserUsage } from '../../../src/utils/index.ts'
+import { addPrefix, getContent, getOptionValue, isOptionSet, parserUsage, toCamel } from '../../../src/utils/index.ts'
 import packageJSON from '../../../package.json'
 
 describe('getContent', () => {
@@ -104,5 +104,105 @@ options:
 
         // then
         expect(consoleOutput).toEqual(expected)
+    })
+})
+
+describe('toCamel', () => {
+    it('should convert snake to camel case', () => {
+        // given
+        const input = {
+            test: {
+                name: 'snake_case',
+                fields: [
+                    {
+                        name: 'field_snake_case'
+                    }
+                ]
+            }
+        }
+
+        // when
+        const result = toCamel(input)
+
+        // then
+        expect(result).toEqual({ test: { name: 'snakeCase', fields: [ { name: 'fieldSnakeCase'}]}})
+    })
+})
+
+describe('addPrefix', () => {
+    it('should add a prefix', () => {
+        // given
+        const input = {
+            test: {
+                name: 'snake_case',
+                fields: [
+                    {
+                        name: 'field_snake_case'
+                    }
+                ]
+            }
+        }
+
+        // when
+        const result = addPrefix(input, 'TEST_')
+
+        // then
+        expect(result).toEqual({ test: { name: 'TEST_snake_case', fields: [ { name: 'field_snake_case'}]}})
+    })
+})
+
+describe('isOptionSet', () => {
+    it('should find the short option value', () => {
+        // given
+        const input = {
+            v: 'asdf'
+        }
+
+        // when
+        const result = isOptionSet(input, 'v', 'verylongargname')
+
+        // then
+        expect(result).toEqual(true)
+    })
+
+    it('should find the long option value', () => {
+        // given
+        const input = {
+            verylongargname: 'asdf'
+        }
+
+        // when
+        const result = isOptionSet(input, 'v', 'verylongargname')
+
+        // then
+        expect(result).toEqual(true)
+    })
+})
+
+describe('getOptionValue', () => {
+    it('should get the short option value', () => {
+        // given
+        const input = {
+            v: 'asdf'
+        }
+
+        // when
+        const result = getOptionValue(input, 'v', 'verylongargname')
+
+        // then
+        expect(result).toEqual('asdf')
+    })
+
+    it('should get the long option value', () => {
+        // given
+        const input = {
+            verylongargname: 'asdf'
+        }
+
+        // when
+        const result = getOptionValue(input, 'v', 'verylongargname')
+
+        // then
+        expect(result).toEqual('asdf')
     })
 })


### PR DESCRIPTION
# graphql-liftoff Developer Pull Request Checklist

### Purpose

- Be able to prefix type names
- Be able to convert snake_case types to camelCase
  
### Checklist
 - [x] Maintainer Code Review - reviewed by Tim
 