### PR TITLE
fix: handle complex types

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,13 +49,17 @@
     "dependencies": {
         "@types/jest": "~21.1.1",
         "@types/js-yaml": "^3.9.1",
+        "@types/lodash": "^4.14.116",
         "@types/node": "~6.0.88",
+        "@types/pluralize": "^0.0.29",
         "@types/request": "^2.0.4",
         "babel-jest": "^21.2.0",
         "babel-plugin-transform-async-to-generator": "^6.24.1",
         "babel-preset-node6": "^11.0.0",
         "js-yaml": "^3.10.0",
+        "lodash": "^4.17.10",
         "oas-raml-converter": "1.0.14",
+        "pluralize": "^7.0.0",
         "request": "^2.83.0",
         "tslib": "~1.7.1",
         "typescript": "~2.5.3"

--- a/src/parsers/swagger/index.ts
+++ b/src/parsers/swagger/index.ts
@@ -1,6 +1,6 @@
 import * as yml from 'js-yaml'
 import * as converter from 'oas-raml-converter'
-import { addPrefix, getOptionValue, isOptionSet, parserUsage, toCamel } from '../../utils'
+import { addPrefix, convertSnakeToPascal, getOptionValue, inferTypeNameFromArrayName, isOptionSet, parserUsage, toCamel } from '../../utils'
 
 let isYAML: boolean = false
 let isPrefix: boolean = false
@@ -54,16 +54,27 @@ function parseDefinitions(definitions: any[], ast: AST = {} as AST): AST {
 function parseDefinition(d: any, ast: AST): void {
     // no duplicate types
     if (!ast[d.name]) {
-        if ((d.internalType === 'object' && d.hasOwnProperty('properties')) || !d.internalType) {
+        if ((d.internalType === 'object' && d.hasOwnProperty('properties')) || !d.internalType || ((d.internalType === 'array') && d.items.hasOwnProperty('properties'))) {
 
             const astType = {} as GraphQLType
 
             // name and description
-            astType.name = d.name
+            if (d.internalType === 'array') {
+                astType.name = inferTypeNameFromArrayName(d.name)
+            }else {
+                astType.name = convertSnakeToPascal(d.name)
+            }
             astType.description = d.description || d._default
 
             // fields
-            astType.fields = d.properties.map((p: any) => {
+            let properties
+            if (d.internalType === 'array') {
+                properties = d.items.properties
+            }else {
+                properties = d.properties
+            }
+
+            astType.fields = properties.map((p: any) => {
                 let name
                 let description
                 let type
@@ -71,12 +82,22 @@ function parseDefinition(d: any, ast: AST): void {
                 name = p.name
                 description = p.description || p._default
 
-                if (p.internalType === 'object') {
-                    type = p.name
+                if (p.internalType === 'object' || (!p.internalType && p.hasOwnProperty('properties'))) {
+                    type = convertSnakeToPascal(p.name)
                     parseDefinition(p, ast)
-                } else if (p.internaltype === 'array') {
-                    type = `[${p.items.reference}]`
-                } else {
+                } else if (p.internalType === 'array') {
+                    if (p.items.reference) {
+                        type = `[${p.items.reference}]`
+                    }else if (p.items.internalType === 'object') {
+                        type = `[${inferTypeNameFromArrayName(p.name)}]`
+                        parseDefinition(p, ast)
+                    }else {
+                        type = `[${convertType(p.internalType)}]`
+                    }
+                }else if (!p.internalType && p.reference) {
+                    type = convertSnakeToPascal(p.reference)
+
+                }else {
                     type = convertType(p.internalType)
                 }
                 return {

--- a/src/parsers/swagger/index.ts
+++ b/src/parsers/swagger/index.ts
@@ -1,6 +1,8 @@
 import * as yml from 'js-yaml'
 import * as converter from 'oas-raml-converter'
-import { addPrefix, convertSnakeToPascal, getOptionValue, inferTypeNameFromArrayName, isOptionSet, parserUsage, toCamel } from '../../utils'
+import * as pluralize from 'pluralize'
+
+import { addPrefix, convertSnakeToPascal, getOptionValue, isOptionSet, parserUsage, toCamel } from '../../utils'
 
 let isYAML: boolean = false
 let isPrefix: boolean = false
@@ -60,7 +62,7 @@ function parseDefinition(d: any, ast: AST): void {
 
             // name and description
             if (d.internalType === 'array') {
-                astType.name = inferTypeNameFromArrayName(d.name)
+                astType.name = convertSnakeToPascal(pluralize(d.name, 1))
             }else {
                 astType.name = convertSnakeToPascal(d.name)
             }
@@ -89,7 +91,7 @@ function parseDefinition(d: any, ast: AST): void {
                     if (p.items.reference) {
                         type = `[${p.items.reference}]`
                     }else if (p.items.internalType === 'object') {
-                        type = `[${inferTypeNameFromArrayName(p.name)}]`
+                        type = `[${convertSnakeToPascal(pluralize(p.name, 1))}]`
                         parseDefinition(p, ast)
                     }else {
                         type = `[${convertType(p.internalType)}]`

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as _ from 'lodash'
 import * as request from 'request'
 import * as pkg from '../../package.json'
 
@@ -47,7 +48,7 @@ export function parserUsage(parser: string, args: Arg[]) {
     })
 }
 
-function convertSnakeToCamel(s: string): string {
+ function convertSnakeToCamel(s: string): string {
     return s.replace(/(\_\w)/g, m => m[1].toUpperCase())
 }
 
@@ -68,11 +69,10 @@ export function toCamel(ast: AST): AST {
 }
 
 export function addPrefix(ast: AST, prefix: String): AST {
-    console.log("inside addPrefix")
-    console.log(JSON.stringify(ast))
-    const types = Object.keys(ast).map((f: any) => {
-        return ast[f].name
-    })
+
+
+    const types = _.map(ast, 'name')
+
     return Object
         .keys(ast)
         .reduce((acc: AST, cur: string) => {
@@ -106,15 +106,4 @@ export function getOptionValue(options: any, short: string, long: string): any {
 
 export function convertSnakeToPascal(s: string): string {
     return convertSnakeToCamel(s).replace(/^\w/, c => c.toUpperCase())
-}
-
-export function inferTypeNameFromArrayName(arrayName: any): string {
-    // If the last character of the array name is 's', it removes the last character and conver remaining string to Pascal Case,
-    // Otherwise, it simply converts the name to Pascal Case. 
-    // It sometime generates name that may not be appropriate e.g.vendorReturnPolicies: [AAA_VendorReturnPolicie] 
-    if (arrayName.charAt(arrayName.length - 1) === 's') {
-        return convertSnakeToPascal(arrayName.slice(0, -1))
-    }else{
-        return convertSnakeToPascal(arrayName)
-    }
 }

--- a/test/unit/utils/index.spec.js
+++ b/test/unit/utils/index.spec.js
@@ -113,9 +113,11 @@ describe('toCamel', () => {
         const input = {
             test: {
                 name: 'snake_case',
+                description: 'description1',
                 fields: [
                     {
-                        name: 'field_snake_case'
+                        name: 'field_snake_case',
+                        description: 'some description'
                     }
                 ]
             }
@@ -125,7 +127,22 @@ describe('toCamel', () => {
         const result = toCamel(input)
 
         // then
-        expect(result).toEqual({ test: { name: 'snakeCase', fields: [ { name: 'fieldSnakeCase'}]}})
+        // expect(result).toEqual({ test: { name: 'snakeCase', fields: [ { name: 'fieldSnakeCase'}]}})
+        expect(result).toEqual(
+            {
+                test: {
+                  name: 'SnakeCase',
+                  description: 'description1',
+                  fields: [
+                    {
+                      description: 'some description',
+                      name: 'fieldSnakeCase'
+                    }
+                  ]
+                }
+              }
+        )
+
     })
 })
 
@@ -133,11 +150,36 @@ describe('addPrefix', () => {
     it('should add a prefix', () => {
         // given
         const input = {
-            test: {
-                name: 'snake_case',
+            someType: {
+                name: 'SomeType',
+                description: 'test description',
                 fields: [
                     {
-                        name: 'field_snake_case'
+                        name: 'some_field',
+                        type: 'abc',
+                        description: 'test description'
+                    }
+                ]
+            },
+            test1: {
+                name: 'snake_case',
+                description: 'test description',
+                fields: [
+                    {
+                        name: 'field_snake_case',
+                        type: 'SomeType',
+                        description: 'test description'
+                    }
+                ]
+            },
+            test2: {
+                name: 'another_snake_case',
+                description: 'test description',
+                fields: [
+                    {
+                        name: 'field_snake_case',
+                        type: '[SomeType]',
+                        description: 'test description'
                     }
                 ]
             }
@@ -147,7 +189,43 @@ describe('addPrefix', () => {
         const result = addPrefix(input, 'TEST_')
 
         // then
-        expect(result).toEqual({ test: { name: 'TEST_snake_case', fields: [ { name: 'field_snake_case'}]}})
+        expect(result).toEqual(
+            {
+                someType: {
+                  description: 'test description',
+                  fields: [
+                    {
+                      description: 'test description',
+                      name: 'some_field',
+                      type: 'abc'
+                    }
+                  ],
+                  name: 'TEST_SomeType'
+                },
+                test1: {
+                  description: 'test description',
+                  fields: [
+                    {
+                      description: 'test description',
+                      name: 'field_snake_case',
+                      type: 'TEST_SomeType'
+                    }
+                  ],
+                  name: 'TEST_snake_case'
+                },
+                test2: {
+                  description: 'test description',
+                  fields: [
+                    {
+                      description: 'test description',
+                      name: 'field_snake_case',
+                      type: '[TEST_SomeType]'
+                    }
+                  ],
+                  name: 'TEST_another_snake_case'
+                }
+              }
+        )
     })
 })
 

--- a/test/unit/utils/index.spec.js
+++ b/test/unit/utils/index.spec.js
@@ -127,7 +127,6 @@ describe('toCamel', () => {
         const result = toCamel(input)
 
         // then
-        // expect(result).toEqual({ test: { name: 'snakeCase', fields: [ { name: 'fieldSnakeCase'}]}})
         expect(result).toEqual(
             {
                 test: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.9.1.tgz#2f3c142771bb345829ce690c5838760b6b9ba553"
 
+"@types/lodash@^4.14.116":
+  version "4.14.116"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
+
 "@types/node@*":
   version "8.0.34"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.34.tgz#55f801fa2ddb2a40dd6dfc15ecfe1dde9c129fe9"
@@ -23,6 +27,10 @@
 "@types/node@~6.0.88":
   version "6.0.89"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.89.tgz#154be0e6a823760cd6083aa8c48f952e2e63e0b0"
+
+"@types/pluralize@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.29.tgz#6ffa33ed1fc8813c469b859681d09707eb40d03c"
 
 "@types/request@^2.0.4":
   version "2.0.4"
@@ -1813,6 +1821,10 @@ lodash@4.x.x, lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
@@ -2248,6 +2260,10 @@ pinkie@^2.0.0:
 pluralize@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR handles following:
1. Type names should be in Pascal Case.
2. Fix for issue where fields with complex type are defaulted to String
3. GraphQL Type defintion not generated for nested objects that are defined in-line in swagger spec.




 