### PR TITLE
Fix typescript external dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     },
     "scripts": {
         "clean": "rimraf coverage build tmp",
-        "install": "node_modules/typescript/bin/tsc",
-        "build": "node_modules/typescript/bin/tsc",
-        "watch": "node_modules/typescript/bin/tsc -w",
+        "install": "tsc",
+        "build": "tsc",
+        "watch": "tsc -w",
         "lint": "tslint -t stylish --type-check --project \"tsconfig.json\"",
         "pretest": "tslint -t stylish --type-check --project \"tsconfig.json\"",
         "test": "jest --no-cache --coverage",


### PR DESCRIPTION
### Purpose

What: Update path to tsc in npm scripts

Why: When initially writing this code, I had assumed that the path I provided
to the typescript compiler in the npm scripts was referencing the locally
installed version of typescript. I was wrong. It still references the
globally installed version.

This presents two major issues:

- Users will not be able to install / run without typescript pre-installed
  globally in either npm or yarn.
- Not using a pinned local version of typescript opens this to future
  incompatibility breakage.

Resolves https://github.com/target/graphql-liftoff/issues/23